### PR TITLE
Fix Changing Effect During Active Transition from Running Effect

### DIFF
--- a/components/light/light_call.cpp
+++ b/components/light/light_call.cpp
@@ -42,8 +42,15 @@ void LightCall::perform() {
 
     bool super = true;
 
+    // is the effect being set/cleared?
+    if (this->has_effect_())
+    {
+      super = false;
+      ESP_LOGD("KAUF Transition Filter", "Want to set an effect @ index %ud", this->effect_);
+    }
+
     // is color mode the same?
-    if ( v.get_color_mode() != this->parent_->remote_values.get_color_mode()) {
+    else if ( v.get_color_mode() != this->parent_->remote_values.get_color_mode()) {
       super = false;
       ESP_LOGV("KAUF Transition Filter","Color Mode different");
     }


### PR DESCRIPTION
A lot of effects will have transitions. The way the code currently works, if the call to change/stop an effect is done while a transition from said effect is running, it will cause a "Double light call detected" and not change the effect. This code change allows the publish to go through if there is an effect included in it, making it more reliable to change/stop an effect.