### PR TITLE
Update transformer_active to match ESPHome

### DIFF
--- a/components/light/light_call.cpp
+++ b/components/light/light_call.cpp
@@ -38,7 +38,7 @@ void LightCall::perform() {
   // Can't figure out why Home Assistant is sending two calls in a row sometimes.  Screwing with fade.
 
   // don't do any checks if not in transition
-  if ( this->parent_->transformer_active ) {
+  if ( this->parent_->is_transformer_active() ) {
 
     bool super = true;
 

--- a/components/light/light_state.cpp
+++ b/components/light/light_state.cpp
@@ -144,7 +144,7 @@ void LightState::loop() {
   // Apply transformer (if any)
   if (this->transformer_ != nullptr) {
     auto values = this->transformer_->apply();
-    this->transformer_active = true;
+    this->is_transformer_active_ = true;
     if (values.has_value()) {
       this->current_values = *values;
       this->output_->update_state(this);
@@ -156,7 +156,7 @@ void LightState::loop() {
       this->current_values = this->transformer_->get_target_values();
 
       this->transformer_->stop();
-      this->transformer_active = false;
+      this->is_transformer_active_ = false;
       this->transformer_ = nullptr;
       this->target_state_reached_callback_.call();
     }
@@ -457,6 +457,8 @@ void LightState::current_values_as_ct(float *color_temperature, float *white_bri
                              this->gamma_correct_);
 }
 
+bool LightState::is_transformer_active() { return this->is_transformer_active_; }
+
 void LightState::start_effect_(uint32_t effect_index) {
   this->stop_effect_();
   if (effect_index == 0)
@@ -506,7 +508,7 @@ void LightState::start_flash_(const LightColorValues &target, uint32_t length, b
 }
 
 void LightState::set_immediately_(const LightColorValues &target, bool set_remote_values) {
-  this->transformer_active = false;
+  this->is_transformer_active_ = false;
   this->transformer_ = nullptr;
   this->current_values = target;
   if (set_remote_values) {

--- a/components/light/light_state.h
+++ b/components/light/light_state.h
@@ -168,7 +168,16 @@ class LightState : public EntityBase, public Component {
 
   void current_values_as_ct(float *color_temperature, float *white_brightness);
 
-  bool transformer_active = false;
+  /**
+   * Indicator if a transformer (e.g. transition) is active. This is useful
+   * for effects e.g. at the start of the apply() method, add a check like:
+   *
+   * if (this->state_->is_transformer_active()) {
+   *   // Something is already running.
+   *   return;
+   * }
+   */
+  bool is_transformer_active();
 
   /// Save the current remote_values to the preferences
   void save_remote_values_();
@@ -250,6 +259,9 @@ protected:
   LightRestoreMode restore_mode_;
   /// List of effects for this light.
   std::vector<LightEffect *> effects_;
+
+  // for effects, true if a transformer (transition) is active.
+  bool is_transformer_active_ = false;
 
   bool use_wled_ = false;
   uint32_t ddp_debug_ = 0;


### PR DESCRIPTION
The flag to indicate if a transformer/transition is active is incredibly useful for effects. When looking at making a pull request for new effects in ESPHome, I realized that flag was not there. I created a pull request (https://github.com/esphome/esphome/pull/6157) and the feedback was to make the field protected and add an accessor method. This pull requests merges those changes made in ESPHome into the Kauf tree.